### PR TITLE
Add indicators onto the gallery.

### DIFF
--- a/public/gallery/gallery.html
+++ b/public/gallery/gallery.html
@@ -30,7 +30,12 @@
             </div>
         </nav>
         <div class="container" id="gallery">
-              <div id="carouselExampleControls" class="carousel slide" data-ride="carousel">
+              <div id="carouselExampleIndicators" class="carousel slide" data-ride="carousel">
+                <ol class="carousel-indicators">
+                  <li data-target="#carouselExampleIndicators" data-slide-to="0" class="active"></li>
+                  <li data-target="#carouselExampleIndicators" data-slide-to="1"></li>
+                  <li data-target="#carouselExampleIndicators" data-slide-to="2"></li>
+                </ol>
                 <div class="carousel-inner">
                   <div class="carousel-item active">
                     <img class="d-block w-100" src="https://i.pinimg.com/564x/90/41/90/904190069236bcab2755ac1000f14e50.jpg">
@@ -42,11 +47,11 @@
                     <img class="d-block w-100" src="../resources/mookie.jpg" alt="Second slide">
                   </div>
                 </div>
-                <a class="carousel-control-prev" href="#carouselExampleControls" role="button" data-slide="prev">
+                <a class="carousel-control-prev" href="#carouselExampleIndicators" role="button" data-slide="prev">
                   <span class="carousel-control-prev-icon" aria-hidden="true"></span>
                   <span class="sr-only">Previous</span>
                 </a>
-                <a class="carousel-control-next" href="#carouselExampleControls" role="button" data-slide="next">
+                <a class="carousel-control-next" href="#carouselExampleIndicators" role="button" data-slide="next">
                   <span class="carousel-control-next-icon" aria-hidden="true"></span>
                   <span class="sr-only">Next</span>
                 </a>


### PR DESCRIPTION
Adding indicators at the bottom of the gallery. Currently, the user can only travel one picture forward or backward. With this new feature, the user can easily select whichever picture they would like to see.